### PR TITLE
Unit Test test_assimilate_errror bug fixed

### DIFF
--- a/Testing/test_tiles2gpkg.py
+++ b/Testing/test_tiles2gpkg.py
@@ -461,8 +461,7 @@ class Testgeopackage:
         with Geopackage(session_folder, 3395) as gpkg:
             with raises(IOError):
                 gpkg.assimilate("None")        
-        remove(join(getcwd(), gpkg.file_path))
-        
+        remove(join(getcwd(), gpkg.file_path)) 
 
     def test_execute_return(self):
         session_folder = make_session_folder()

--- a/Testing/test_tiles2gpkg.py
+++ b/Testing/test_tiles2gpkg.py
@@ -458,10 +458,11 @@ class Testgeopackage:
     def test_assimilate_error(self):
         session_folder = make_session_folder()
         chdir(session_folder)
-        gpkg = Geopackage(session_folder, 3395)
+        with Geopackage(session_folder, 3395) as gpkg:
+            with raises(IOError):
+                gpkg.assimilate("None")        
         remove(join(getcwd(), gpkg.file_path))
-        with raises(IOError):
-            gpkg.assimilate("None")
+        
 
     def test_execute_return(self):
         session_folder = make_session_folder()


### PR DESCRIPTION
Fixed a bug with the unit test test_assimilate_error test by adding an
extra with statement.
This ensures the Geopackage object is closed before it is removed